### PR TITLE
Updates and fully function on Blender4.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 # Blender files unless it is the main Simulator.blend file
 *.blend
 *.blend1
-!Simulator.blend
+# !Simulator.blend  # These can become large binary files, toggle commented line if you want to use it during development, revert before pull request
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -137,4 +137,3 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-Simulator.blend

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+Simulator.blend

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Quantum Microcope
+# Quantum Microscope
 
 Quantum Microscope is an open source add-on to Blender, simulating subatomic particles and the formation of matter using classical physics. It provides a microscopic look at molecules, atoms, atomic nuclei, particles and spacetime, using the theoretical model from Energy Wave Theory (EWT).
 

--- a/common/functions.py
+++ b/common/functions.py
@@ -210,7 +210,7 @@ def add_electron(name, color, scale_factor=1, core_only=False, antimatter=False)
         x += 1
         bpy.ops.object.select_pattern(pattern=name + "*")
         bpy.ops.object.join()
-        bpy.context.active_object.name = name  # Makes sure name of object result of join is correct
+        bpy.context.active_object.name = name  # Make sure name of resulting object is correct
         bpy.ops.object.origin_set(type='ORIGIN_GEOMETRY', center='MEDIAN')
         o = bpy.data.objects[name]
         if antimatter:

--- a/common/functions.py
+++ b/common/functions.py
@@ -210,6 +210,7 @@ def add_electron(name, color, scale_factor=1, core_only=False, antimatter=False)
         x += 1
         bpy.ops.object.select_pattern(pattern=name + "*")
         bpy.ops.object.join()
+        bpy.context.active_object.name = name  # Makes sure name of object result of join is correct
         bpy.ops.object.origin_set(type='ORIGIN_GEOMETRY', center='MEDIAN')
         o = bpy.data.objects[name]
         if antimatter:


### PR DESCRIPTION
Hi Jeff, I found the problem with the new blender version, wasn’t as hard as i thought, your code is very well documented inline!

ISSUE was: on recent blender python versions the `bpy.ops.object.join` function was getting lost in which object name to use for the joint collection, and by using anything different than “Electron” was breaking downstream call functions.

Issue fixed, tested and committed … now QScope is compatible with Blender4.1!, on your workflow for merging whenever	you want.

Also added inline note to better deal with `Simulator.blender` files. Now as default, `Simulator.blend` is ignored by Git. An inline note describes option to change that for dev environments. These .blender can become large binary files, useful during dev but not desired at master branch, so developer can toggle commented line if wants to use it during development, but revert before pull request.

Now i’ll continue my studies of the amazing EWT!

best,
R